### PR TITLE
Fix:TestEngine with ID 'junit-vintage' failed to discover tests faile…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -184,11 +184,6 @@ Import-Package: javax.annotation;version=0.0.0,*
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit-addons</groupId>
-            <artifactId>junit-addons</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
             <exclusions>


### PR DESCRIPTION
…d to parse version of junit:junit: 4.13.1 according to https://youtrack.jetbrains.com/issue/IDEA-257728#focus=Comments-27-4657781.0-0